### PR TITLE
Switch to debian 9 slim image and cut down arm-none-eabi slightly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM debian:9-slim
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     avr-libc \
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     clang \
     dfu-programmer \
     dfu-util \
+    ca-certificates \
     gcc \
     gcc-avr \
     git \
@@ -18,6 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-setuptools \
     software-properties-common \
     unzip \
+    tar \
     wget \
     zip \
     && rm -rf /var/lib/apt/lists/*
@@ -26,5 +28,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN pip3 install argcomplete colorama nose2
 
 # upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | \
-    tar xj --strip-components=1 -C /
+RUN set -o pipefail && \
+    wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | tar xj --strip-components=1 -C / && \
+    rm -rf /arm-none-eabi/share/ /share/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN pip3 install argcomplete colorama nose2
 
 # upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues
-RUN set -o pipefail && \
+RUN /bin/bash -c "set -o pipefail && \
     wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | tar xj --strip-components=1 -C / && \
-    rm -rf /arm-none-eabi/share/ /share/
+    rm -rf /arm-none-eabi/share/ /share/"


### PR DESCRIPTION
Given best practice is to prefer slim images, I have swapped the base image over (and cut down 50MB of potentially unnecessary arm-none-eabi stuff).

While i have tested this with qmk_firmware, I am not sure on the implications for qmk_compiler. 