### PR TITLE
Update base image to slim 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9-slim
+FROM debian:10-slim
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     avr-libc \


### PR DESCRIPTION
Debian Buster has had a fair few months now to stabilise. Stretch will EOL some point during 2020.

Tested building AVR and ARM qmk_firmware boards, and some cli commands.
**Needs some eyes on for infra requirements.**

Required to unblock #6.