### PR TITLE
Change clang to clang-format to fix `qmk pytest`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-avr \
     build-essential \
     ca-certificates \
-    clang \
+    clang-format \
     dfu-programmer \
     dfu-util \
     ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     binutils-avr \
     build-essential \
     ca-certificates \
-    clang-format \
+    clang-format-7 \
     dfu-programmer \
     dfu-util \
     ca-certificates \


### PR DESCRIPTION
When this line was originally added the intention was to install `clang-format`, but today it seems that doesn't actually install `clang-format`. We specify version 7 because the default (version 4) does not support IndentPPDirectives.