### PR TITLE
Install ccache within container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     dfu-programmer \
     dfu-util \
     ca-certificates \
+    ccache \
     gcc \
     gcc-avr \
     git \


### PR DESCRIPTION
Allows ccache to be used within CI so that qmk_firmware PR builds can potentially be a bit faster.