### PR TITLE
Add missing teensy-loader-cli package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-setuptools \
     software-properties-common \
     tar \
+    teensy-loader-cli \
     unzip \
     tar \
     wget \


### PR DESCRIPTION
Without this it's not possible to flash the firmware for (e.g.) the Ergodox EZ.