### PR TITLE
Update docker image to Debian 11 and add support for risc-v builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
-FROM debian:10-slim
+FROM debian:11-slim
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     avr-libc \
     avrdude \
     binutils-arm-none-eabi \
     binutils-avr \
+    binutils-riscv64-unknown-elf \
     build-essential \
     ca-certificates \
-    clang-format-7 \
+    clang-format-11 \
     dfu-programmer \
     dfu-util \
     dos2unix \
     ca-certificates \
     gcc \
     gcc-avr \
+    gcc-arm-none-eabi \
+    gcc-riscv64-unknown-elf \
     git \
     libnewlib-arm-none-eabi \
+    picolibc-riscv64-unknown-elf \
     python3 \
     python3-pip \
     software-properties-common \
@@ -26,11 +30,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     wget \
     zip \
     && rm -rf /var/lib/apt/lists/*
-
-# upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues
-RUN /bin/bash -c "set -o pipefail && \
-    wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | tar xj --strip-components=1 -C / && \
-    rm -rf /arm-none-eabi/share/ /share/"
 
 # Install python packages
 RUN python3 -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

In preperation for the [RISC-V QMK support](https://github.com/qmk/qmk_firmware/pull/12508) this PR adds the needed toolchains to the QMK base container.

Debian 11 "Bullseye" supports RISC-V builds with gcc and picolibc by default. This commit also updates clang-format to version 11 and removes the downloaded gcc arm toolchain as the packaged version is newer and provided by ARM as well.


<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
