### PR TITLE
No provenance.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,3 +51,4 @@ jobs:
           tags: |
             ghcr.io/qmk/qmk_base_container:latest
             qmkfm/base_container:latest
+          provenance: false


### PR DESCRIPTION
See:

https://github.com/docker/bake-action/pull/104
[docker.com/blog/highlights-buildkit-v0-11-release](https://www.docker.com/blog/highlights-buildkit-v0-11-release/)
[docs.docker.com/build/attestations/attestation-storage/#attestation-manifest](https://docs.docker.com/build/attestations/attestation-storage/#attestation-manifest)
https://github.com/docker/build-push-action/pull/746
https://github.com/docker/buildx/issues/1509
https://github.com/docker/build-push-action/issues/764