### PR TITLE
Install ccache and gh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:13-slim
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
     ca-certificates \
+    ccache \
     clang-format \
     curl \
     diffutils \
@@ -21,4 +22,13 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     wget \
     zip \
     zstd \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+&& wget -nv https://cli.github.com/packages/githubcli-archive-keyring.gpg -O /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& mkdir -p -m 755 /etc/apt/sources.list.d \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+&& apt-get update && apt-get install -y \
+    gh \
 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
Installs the following dependencies:
* ccache
* github cli
  * Version in debian 13 too old to allow `gh cache delete --ref` - Installed latest with steps adapted from [official docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian).